### PR TITLE
Create my-github.txt

### DIFF
--- a/my-github.txt
+++ b/my-github.txt
@@ -1,0 +1,74 @@
+一，GitHub是一种分布式版本控制系统（记录每次文件的改动）
+分布式与集中式区别。集中式：各个电脑从中央服务器的版本库中取得新版本，用完后，把成果推送给中央服务器，缺点：要联网，中央服务器一旦坏了，会牵制所用工作。
+分布式：版本库就在自己的电脑中，不需要联网，若使用一台电脑充当"中央服务器"，可方便交换大家的修改。
+二，版本库（repository）
+可以理解为一个目录
+git init 用于将目录变为git可管理的仓库
+pwd 用于显示当前目录
+mkdir 目录名 
+cd目录名  进入这个目录
+git init后 目录会多一个
+三 git 只能跟踪文本文件的改动 ，二进制文件不行（例如只知道图片从100kb变成了120kb，却不知道变了什么），由于Microsoft的Word是二进制格式。
+文本有编码，建议使用标准的UTF-8编码
+四 注意：千万不要使用Windows自带的记事本编辑任何文本文件
+
+具体操作
+一（创建版本库）：初始步骤第一步，新编辑一个文本文档 将其放在实现变成目录的仓库中
+用git add  文件名 将文件添加到仓库里，可添加多个文件
+第二步  git commit -m ‘message’来确定文件发生了怎样的改变
+二（观察修改情况）： git status命令用于时刻掌握仓库当前的状态（告诉我们有没有未提交的修改）
+git diff  文件名 可以查看具体的修改
+cat  文件名  查看文件内容
+三：做出修改后需要重新提交（一）
+四（了解修改历史）：git log命令可显示从最近到最远的提交日志，若嫌输出信息太多，可以加上--pretty=oneline参数//日志太长时可能会导致无法输出，按q键可解决问题
+五（时光穿梭机）:git reset --hard HEAD~x(回退x个版本)//HEAD指的是当前所指向的版本
+git reset --hard 版本号前几位数字，可以找回原来版本
+git reflog记录每一次命令
+六 工作区与暂存区
+
+七：git管理的是修改
+只有通过git add 放入暂存区的修改，才能通过git commit提交
+若修改未被add 可以用git checkout -- 文件名撤销修改（一）。
+若修改被add 但未被commit（二）。
+可用 git reset HEAD 文件名将暂存区的修改放回到工作区，在调用（一）。
+若修改也被commit了，可以使用版本回退功能。（三）。
+若修改被推送到了远程版本库，无计可施。
+八：文件删除
+rm 文件名 可删除文件
+rm之后有两个选择 1：确定要删除文件 git rm 文件名 然后git commit
+2：删错了 git checkout -- 文件名
+九：远程仓库
+1，要关联一个远程库，使用命令git remote add origin git@server-name:repo-name.git   
+关联后，使用命令 git push -u origin master第一次推送master分支的所有内容
+此后，每次本地提交后，只要有必要，就可以使用命令git push origin master推送新的修改
+2，要克隆一个仓库，首先必须知道仓库的地址，然后使用git clone git@server-name:repo-name/文件名.git进行克隆
+十：分支管理
+1，（创建和合并分支）git checkout -b 分支名 创建并切换到这个新分支
+git branch列出所有分支，当前分支前面会标有一个※
+git merge 分支名 合并某分支到当前分支
+git branch -d 分支名 删除某分支 
+分支所做的修改在合并前不影响其他分支
+2，（解决冲突）当不同的分支做了不同的修改后进行合并，可能会引发冲突，直接查看文件内容，自行修改后在提交即可  git log --graph可看到合并分支图
+3，（合并模式）若用Fast forward模式，删除分支后会丢失分支信息
+通过git merge --no-ff -m “message” 分支名可以禁用Fast forward模式
+4，（bug修复）通过创建分支，修复bug在合并到主分支上。
+5，（工作现场暂时储存）git stash可以将当前工作分支先储存起来，通过git stash list可找寻被储存的工作分支，再通过git stash pop恢复并删除stash内容
+如果储存了很多，只想先恢复一个 ，可以用git stash apply stash@{对应的数字编号}
+6：未合并的分支要删除的话得强行删除（d改为D），新添功能时要新建一个feature分支，分支名为feature-文件名前缀
+7：（多人协作）git remote命令可以看远程库信息           多人协作模式首先，可以试图用git push origin  分支名 推送自己的修改；
+如果推送失败，则因为远程分支比你的本地更新，需要先用git pull试图合并；
+如果合并有冲突，则解决冲突，并在本地提交；
+没有冲突或者解决掉冲突后，再用git push origin 分支名 推送就能成功！
+如果git pull提示no tracking information，则说明本地分支和远程分支的链接关系没有创建，用命令git branch --set-upstream-to 分支名origin/分支名。
+8：（强迫症福音）git rebase操作可以把本地未push的分叉提交历史整理成直线
+十一：赋予版本号标签以方便称呼
+1：创建标签用git tag 标签名         git tag命令可以观看所有标签
+对某个之前的版本打标签，需要先知道commit id，然后git tag 标签名 commit id
+2：git show 标签名查看标签对应的版本及版本信息
+3：git tag -a 标签名 -m "你要写的备注"
+4：推送某个标签到远程 git push origin 标签名   git push origin --tags 推送所有标签
+5：git tag -d 标签名 用于删除本地标签（一） 
+若标签被推送到远程，要删除，先（一），删除本地标签 
+然后 git push origin ：refs/tags/标签名
+要想知道是否真的已经删除了标签，可以登录github观看
+


### PR DESCRIPTION
一，GitHub是一种分布式版本控制系统（记录每次文件的改动）
分布式与集中式区别。集中式：各个电脑从中央服务器的版本库中取得新版本，用完后，把成果推送给中央服务器，缺点：要联网，中央服务器一旦坏了，会牵制所用工作。
分布式：版本库就在自己的电脑中，不需要联网，若使用一台电脑充当"中央服务器"，可方便交换大家的修改。
二，版本库（repository）
可以理解为一个目录
git init 用于将目录变为git可管理的仓库
pwd 用于显示当前目录
mkdir 目录名 
cd目录名  进入这个目录
git init后 目录会多一个
三 git 只能跟踪文本文件的改动 ，二进制文件不行（例如只知道图片从100kb变成了120kb，却不知道变了什么），由于Microsoft的Word是二进制格式。
文本有编码，建议使用标准的UTF-8编码
四 注意：千万不要使用Windows自带的记事本编辑任何文本文件

具体操作
一（创建版本库）：初始步骤第一步，新编辑一个文本文档 将其放在实现变成目录的仓库中
用git add  文件名 将文件添加到仓库里，可添加多个文件
第二步  git commit -m ‘message’来确定文件发生了怎样的改变
二（观察修改情况）： git status命令用于时刻掌握仓库当前的状态（告诉我们有没有未提交的修改）
git diff  文件名 可以查看具体的修改
cat  文件名  查看文件内容
三：做出修改后需要重新提交（一）
四（了解修改历史）：git log命令可显示从最近到最远的提交日志，若嫌输出信息太多，可以加上--pretty=oneline参数//日志太长时可能会导致无法输出，按q键可解决问题
五（时光穿梭机）:git reset --hard HEAD~x(回退x个版本)//HEAD指的是当前所指向的版本
git reset --hard 版本号前几位数字，可以找回原来版本
git reflog记录每一次命令
六 工作区与暂存区

七：git管理的是修改
只有通过git add 放入暂存区的修改，才能通过git commit提交
若修改未被add 可以用git checkout -- 文件名撤销修改（一）。
若修改被add 但未被commit（二）。
可用 git reset HEAD 文件名将暂存区的修改放回到工作区，在调用（一）。
若修改也被commit了，可以使用版本回退功能。（三）。
若修改被推送到了远程版本库，无计可施。
八：文件删除
rm 文件名 可删除文件
rm之后有两个选择 1：确定要删除文件 git rm 文件名 然后git commit
2：删错了 git checkout -- 文件名
九：远程仓库
1，要关联一个远程库，使用命令git remote add origin git@server-name:repo-name.git   
关联后，使用命令 git push -u origin master第一次推送master分支的所有内容
此后，每次本地提交后，只要有必要，就可以使用命令git push origin master推送新的修改
2，要克隆一个仓库，首先必须知道仓库的地址，然后使用git clone git@server-name:repo-name/文件名.git进行克隆
十：分支管理
1，（创建和合并分支）git checkout -b 分支名 创建并切换到这个新分支
git branch列出所有分支，当前分支前面会标有一个※
git merge 分支名 合并某分支到当前分支
git branch -d 分支名 删除某分支 
分支所做的修改在合并前不影响其他分支
2，（解决冲突）当不同的分支做了不同的修改后进行合并，可能会引发冲突，直接查看文件内容，自行修改后在提交即可  git log --graph可看到合并分支图
3，（合并模式）若用Fast forward模式，删除分支后会丢失分支信息
通过git merge --no-ff -m “message” 分支名可以禁用Fast forward模式
4，（bug修复）通过创建分支，修复bug在合并到主分支上。
5，（工作现场暂时储存）git stash可以将当前工作分支先储存起来，通过git stash list可找寻被储存的工作分支，再通过git stash pop恢复并删除stash内容
如果储存了很多，只想先恢复一个 ，可以用git stash apply stash@{对应的数字编号}
6：未合并的分支要删除的话得强行删除（d改为D），新添功能时要新建一个feature分支，分支名为feature-文件名前缀
7：（多人协作）git remote命令可以看远程库信息           多人协作模式首先，可以试图用git push origin  分支名 推送自己的修改；
如果推送失败，则因为远程分支比你的本地更新，需要先用git pull试图合并；
如果合并有冲突，则解决冲突，并在本地提交；
没有冲突或者解决掉冲突后，再用git push origin 分支名 推送就能成功！
如果git pull提示no tracking information，则说明本地分支和远程分支的链接关系没有创建，用命令git branch --set-upstream-to 分支名origin/分支名。
8：（强迫症福音）git rebase操作可以把本地未push的分叉提交历史整理成直线
十一：赋予版本号标签以方便称呼
1：创建标签用git tag 标签名         git tag命令可以观看所有标签
对某个之前的版本打标签，需要先知道commit id，然后git tag 标签名 commit id
2：git show 标签名查看标签对应的版本及版本信息
3：git tag -a 标签名 -m "你要写的备注"
4：推送某个标签到远程 git push origin 标签名   git push origin --tags 推送所有标签
5：git tag -d 标签名 用于删除本地标签（一） 
若标签被推送到远程，要删除，先（一），删除本地标签 
然后 git push origin ：refs/tags/标签名
要想知道是否真的已经删除了标签，可以登录github观看

